### PR TITLE
Updated names in transdanubia

### DIFF
--- a/data/404/227/491/404227491.geojson
+++ b/data/404/227/491/404227491.geojson
@@ -12,14 +12,10 @@
     "iso:country":"HU",
     "lbl:max_zoom":7.0,
     "lbl:min_zoom":5.0,
-    "mz:categories":[],
     "mz:hierarchy_label":1,
-    "mz:hours":[],
     "mz:is_current":1,
     "mz:min_zoom":3.0,
-    "name:ara_x_colloquial":[],
-    "name:ara_x_preferred":[],
-    "name:ara_x_variant":[
+    "name:ara_x_preferred":[
         "\u062a\u0631\u0627\u0646\u0633\u062f\u0627\u0646\u0648\u0628\u064a\u0627 \u0627\u0644\u062c\u0646\u0648\u0628\u064a\u0629"
     ],
     "name:aze_x_preferred":[
@@ -28,15 +24,9 @@
     "name:bel_x_preferred":[
         "\u041f\u0430\u045e\u0434\u043d\u0451\u0432\u0430-\u0417\u0430\u0434\u0443\u043d\u0430\u0439\u0441\u043a\u0456 \u043a\u0440\u0430\u0439"
     ],
-    "name:ben_x_colloquial":[],
-    "name:ben_x_preferred":[],
-    "name:ben_x_variant":[],
-    "name:deu_x_preferred":[],
-    "name:deu_x_variant":[
+    "name:deu_x_preferred":[
         "S\u00fcdtransdanubien"
     ],
-    "name:ell_x_preferred":[],
-    "name:eng_x_colloquial":[],
     "name:eng_x_preferred":[
         "Southern Transdanubia"
     ],
@@ -52,47 +42,24 @@
     "name:fas_x_preferred":[
         "\u062a\u0631\u0627\u0646\u0633\u062f\u0627\u0646\u0648\u0628\u06cc\u0627 \u062c\u0646\u0648\u0628\u06cc"
     ],
-    "name:fra_x_preferred":[],
-    "name:fra_x_variant":[
+    "name:fra_x_preferred":[
         "Transdanubie m\u00e9ridionale"
-    ],
-    "name:fre_x_colloquial":[],
-    "name:fre_x_variant":[
-        "Transdanubie m\u00e9ridionale"
-    ],
-    "name:ger_x_colloquial":[],
-    "name:ger_x_variant":[
-        "S\u00fcdtransdanubien"
     ],
     "name:glg_x_preferred":[
         "Transdanubia meridional"
     ],
-    "name:gre_x_colloquial":[],
-    "name:gre_x_variant":[],
     "name:heb_x_preferred":[
         "\u05d3\u05e8\u05d5\u05dd \u05d8\u05e8\u05e0\u05e1\u05d3\u05e0\u05d5\u05d1\u05d9\u05d4"
     ],
-    "name:hin_x_colloquial":[],
-    "name:hin_x_preferred":[],
-    "name:hin_x_variant":[],
     "name:hrv_x_preferred":[
         "Ju\u017eno Zadunavlje"
     ],
-    "name:hun_x_colloquial":[],
     "name:hun_x_preferred":[
         "D\u00e9l-Dun\u00e1nt\u00fal"
     ],
-    "name:ita_x_colloquial":[],
-    "name:ita_x_preferred":[],
-    "name:ita_x_variant":[
+    "name:ita_x_preferred":[
         "Transdanubio Meridionale"
     ],
-    "name:jap_x_colloquial":[],
-    "name:jap_x_preferred":[],
-    "name:jap_x_variant":[],
-    "name:kor_x_colloquial":[],
-    "name:kor_x_preferred":[],
-    "name:kor_x_variant":[],
     "name:mkd_x_preferred":[
         "\u0408\u0443\u0436\u0435\u043d \u043f\u0440\u0435\u043a\u0443\u0434\u0443\u043d\u0430\u0432\u0441\u043a\u0438 \u0440\u0435\u0433\u0438\u043e\u043d"
     ],
@@ -102,26 +69,19 @@
     "name:nno_x_preferred":[
         "S\u00f8r-Transdanubia"
     ],
-    "name:por_x_colloquial":[],
-    "name:por_x_preferred":[],
-    "name:por_x_variant":[],
     "name:que_x_preferred":[
         "D\u00e9l-Dun\u00e1nt\u00fal"
     ],
     "name:ron_x_preferred":[
         "Transdanubia de Sud"
     ],
-    "name:rus_x_colloquial":[],
-    "name:rus_x_preferred":[],
-    "name:rus_x_variant":[
+    "name:rus_x_preferred":[
         "\u042e\u0436\u043d\u043e-\u0417\u0430\u0434\u0443\u043d\u0430\u0439\u0441\u043a\u0438\u0439 \u043a\u0440\u0430\u0439"
     ],
     "name:slv_x_preferred":[
         "Ju\u017ena prekodonavska"
     ],
-    "name:spa_x_colloquial":[],
-    "name:spa_x_preferred":[],
-    "name:spa_x_variant":[
+    "name:spa_x_preferred":[
         "D\u00e9l-Dun\u00e1nt\u00fal"
     ],
     "name:srp_x_preferred":[
@@ -130,24 +90,16 @@
     "name:swe_x_preferred":[
         "S\u00f6dra Transdanubien"
     ],
-    "name:tur_x_colloquial":[],
-    "name:tur_x_preferred":[],
-    "name:tur_x_variant":[
+    "name:tur_x_preferred":[
         "G\u00fcney Transdanubia"
     ],
     "name:ukr_x_preferred":[
         "\u041f\u0456\u0432\u0434\u0435\u043d\u043d\u0435 \u0417\u0430\u0434\u0443\u043d\u0430\u0432'\u044f"
     ],
-    "name:und_x_colloquial":[],
     "name:und_x_variant":[
         "Del-Dunantul"
     ],
-    "name:vie_x_colloquial":[],
-    "name:vie_x_preferred":[],
-    "name:vie_x_variant":[],
-    "name:zho_x_colloquial":[],
-    "name:zho_x_preferred":[],
-    "name:zho_x_variant":[
+    "name:zho_x_vpreferred":[
         "\u591a\u7459\u6cb3\u5357\u90e8"
     ],
     "qs:a0":"Magyarorsz\u00e1g",
@@ -185,7 +137,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1566650434,
+    "wof:lastmodified":1568234561,
     "wof:name":"Southern Transdanubia",
     "wof:parent_id":85633237,
     "wof:placetype":"macroregion",


### PR DESCRIPTION
Fixes the a portion of whosonfirst-data/whosonfirst-data#1709

This PR removes any bunk iso codes/name properties and empty name lists. Unfortunately, the Git history does not reveal where these empty name strings come from. I also ran this record against wikidata to gain new names, but no new names were found.

This does not require PIP work. Can be merged once approved.