### PR TITLE
Updated English name translations for locality

### DIFF
--- a/data/101/790/519/101790519.geojson
+++ b/data/101/790/519/101790519.geojson
@@ -42,7 +42,7 @@
         "Kiskunhalas"
     ],
     "name:eng_x_variant":[
-        "Kiskunhalas"
+        "Kiskunhalos"
     ],
     "name:epo_x_preferred":[
         "Kiskunhalas"
@@ -207,7 +207,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1574293017,
+    "wof:lastmodified":1574294603,
     "wof:name":"Kiskunhalas",
     "wof:parent_id":85684859,
     "wof:placetype":"locality",

--- a/data/101/790/519/101790519.geojson
+++ b/data/101/790/519/101790519.geojson
@@ -39,7 +39,7 @@
         "Kiskunhalas"
     ],
     "name:eng_x_preferred":[
-        "Kiskunhalos"
+        "Kiskunhalas"
     ],
     "name:eng_x_variant":[
         "Kiskunhalas"
@@ -201,10 +201,13 @@
         }
     ],
     "wof:id":101790519,
-    "wof:lang":[
+    "wof:lang_x_official":[
         "hun"
     ],
-    "wof:lastmodified":1566650160,
+    "wof:lang_x_spoken":[
+        "hun"
+    ],
+    "wof:lastmodified":1574293017,
     "wof:name":"Kiskunhalas",
     "wof:parent_id":85684859,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1743

Swaps the variant and preferred English names for the locality of Kiskunhalas, Hungary. No PIP work required, can merge once approved.