### PR TITLE
Pécs (Hungary) (polygon): wrong hu language-specific label

### DIFF
--- a/data/101/751/663/101751663.geojson
+++ b/data/101/751/663/101751663.geojson
@@ -125,14 +125,7 @@
     "name:hrv_x_preferred":[
         "Pe\u010duh"
     ],
-    "name:hun_x_colloquial":[
-        "Funfkirchen"
-    ],
     "name:hun_x_preferred":[
-        "Fuenfkirchen"
-    ],
-    "name:hun_x_variant":[
-        "F\u00fcnfkirchen",
         "P\u00e9cs"
     ],
     "name:hye_x_preferred":[


### PR DESCRIPTION
Noticed this while geocoding using whosonfirst as source: "Pécs", a city in Hungary always appeared as "Fünfkirchen", so I guessed there must be a mistake in the underlying database.
"Pécs" - official name of the city, in Hungarian, therefore the Hungarian language-specific label should be "Pécs" as well, not the german "Fünfkirchen"
"Fünfkirchen" - german name of "Pécs"
Changes:
- deleted name:hun_x_colloquial, name:hun_x_variant: both contained Fünfkirchen, there is no other hu variant for Pécs
- changed name:hun_x_preferred to "P\u00e9cs"