### PR TITLE
hu concordances, placetype local, and more

### DIFF
--- a/data/404/227/477/404227477.geojson
+++ b/data/404/227/477/404227477.geojson
@@ -165,7 +165,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1684351434,
+    "wof:lastmodified":1695884200,
     "wof:name":"Northern Hungary",
     "wof:parent_id":85633237,
     "wof:placetype":"macroregion",

--- a/data/404/227/479/404227479.geojson
+++ b/data/404/227/479/404227479.geojson
@@ -177,7 +177,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1684351434,
+    "wof:lastmodified":1695884200,
     "wof:name":"Central Transdanubia",
     "wof:parent_id":85633237,
     "wof:placetype":"macroregion",

--- a/data/404/227/481/404227481.geojson
+++ b/data/404/227/481/404227481.geojson
@@ -171,7 +171,7 @@
         "wd:id":"Q852716"
     },
     "wof:country":"HU",
-    "wof:geomhash":"f601848486d5077fd96f0e79d091d4a9",
+    "wof:geomhash":"8d323448498b7d069ab283d4dcd6cdba",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -186,7 +186,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690931018,
+    "wof:lastmodified":1695884200,
     "wof:name":"Western Transdanubia",
     "wof:parent_id":85633237,
     "wof:placetype":"macroregion",

--- a/data/404/227/483/404227483.geojson
+++ b/data/404/227/483/404227483.geojson
@@ -171,7 +171,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1684351435,
+    "wof:lastmodified":1695884200,
     "wof:name":"Northern Great Plain",
     "wof:parent_id":85633237,
     "wof:placetype":"macroregion",

--- a/data/404/227/487/404227487.geojson
+++ b/data/404/227/487/404227487.geojson
@@ -168,7 +168,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1684351435,
+    "wof:lastmodified":1695884200,
     "wof:name":"Southern Great Plain",
     "wof:parent_id":85633237,
     "wof:placetype":"macroregion",

--- a/data/404/227/489/404227489.geojson
+++ b/data/404/227/489/404227489.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.824296,
-    "geom:area_square_m":6896797410.941579,
+    "geom:area_square_m":6896797410.941566,
     "geom:bbox":"18.688433,46.944217,20.112707,48.058681",
     "geom:latitude":47.417213,
     "geom:longitude":19.338511,
@@ -172,7 +172,7 @@
         "wd:id":"Q852742"
     },
     "wof:country":"HU",
-    "wof:geomhash":"08393a075ccc629376003b69d91cee8b",
+    "wof:geomhash":"3ffc899a586139aef89cea945690f5bd",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -187,7 +187,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690931019,
+    "wof:lastmodified":1695884150,
     "wof:name":"Central Hungary",
     "wof:parent_id":85633237,
     "wof:placetype":"macroregion",

--- a/data/404/227/491/404227491.geojson
+++ b/data/404/227/491/404227491.geojson
@@ -171,7 +171,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1684351435,
+    "wof:lastmodified":1695884200,
     "wof:name":"Southern Transdanubia",
     "wof:parent_id":85633237,
     "wof:placetype":"macroregion",

--- a/data/856/332/37/85633237.geojson
+++ b/data/856/332/37/85633237.geojson
@@ -1350,6 +1350,7 @@
         "hasc:id":"HU",
         "icao:code":"HA",
         "ioc:id":"HUN",
+        "iso:code":"HU",
         "itu:id":"HNG",
         "loc:id":"n79053090",
         "m49:code":"348",
@@ -1364,6 +1365,7 @@
         "wk:page":"Hungary",
         "wmo:id":"HU"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"HU",
     "wof:country_alpha3":"HUN",
     "wof:geom_alt":[
@@ -1385,7 +1387,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1694492235,
+    "wof:lastmodified":1695881348,
     "wof:name":"Hungary",
     "wof:parent_id":102191581,
     "wof:placetype":"country",

--- a/data/856/848/39/85684839.geojson
+++ b/data/856/848/39/85684839.geojson
@@ -374,12 +374,18 @@
         "gn:id":3055399,
         "gp:id":12577912,
         "hasc:id":"HU.BA",
+        "iso:code":"HU-BA",
         "iso:id":"HU-BA",
+        "qs:local_id":"402",
         "unlc:id":"HU-BA",
         "wd:id":"Q186195"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"2cdf7bb05fe16238b5a6dc000e7d3030",
+    "wof:geomhash":"29bd07bf9074d4e992d546807de352a5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -395,7 +401,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930638,
+    "wof:lastmodified":1695885271,
     "wof:name":"Baranya",
     "wof:parent_id":404227491,
     "wof:placetype":"region",

--- a/data/856/848/41/85684841.geojson
+++ b/data/856/848/41/85684841.geojson
@@ -376,12 +376,18 @@
         "gn:id":3043845,
         "gp:id":12577927,
         "hasc:id":"HU.TO",
+        "iso:code":"HU-TO",
         "iso:id":"HU-TO",
+        "qs:local_id":"417",
         "unlc:id":"HU-TO",
         "wd:id":"Q191625"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"1295fc7a44a7dfec59feae6b29b3c1e5",
+    "wof:geomhash":"a1d35fa4b9e737b7b8eef2475cd2d73e",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -397,7 +403,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930640,
+    "wof:lastmodified":1695885271,
     "wof:name":"Tolna",
     "wof:parent_id":404227491,
     "wof:placetype":"region",

--- a/data/856/848/45/85684845.geojson
+++ b/data/856/848/45/85684845.geojson
@@ -395,12 +395,18 @@
         "gn:id":3045226,
         "gp:id":12577924,
         "hasc:id":"HU.SO",
+        "iso:code":"HU-SO",
         "iso:id":"HU-SO",
+        "qs:local_id":"414",
         "unlc:id":"HU-SO",
         "wd:id":"Q190522"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"56c8d56dd2e6d21e9e26e50e41b38137",
+    "wof:geomhash":"ebea565bbb5e0a26e650c548ec401317",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -416,7 +422,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930637,
+    "wof:lastmodified":1695885271,
     "wof:name":"Somogy",
     "wof:parent_id":404227491,
     "wof:placetype":"region",

--- a/data/856/848/49/85684849.geojson
+++ b/data/856/848/49/85684849.geojson
@@ -397,12 +397,18 @@
         "gn:id":3042613,
         "gp:id":12577930,
         "hasc:id":"HU.ZA",
+        "iso:code":"HU-ZA",
         "iso:id":"HU-ZA",
+        "qs:local_id":"320",
         "unlc:id":"HU-ZA",
         "wd:id":"Q185374"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"f03a3a6c34e56d67028f2fc9f063a932",
+    "wof:geomhash":"8d6f6341c63354ba4c38a71b375c46ed",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -418,7 +424,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930641,
+    "wof:lastmodified":1695885271,
     "wof:name":"Zala",
     "wof:parent_id":404227481,
     "wof:placetype":"region",

--- a/data/856/848/55/85684855.geojson
+++ b/data/856/848/55/85684855.geojson
@@ -465,12 +465,18 @@
         "gn:id":721589,
         "gp:id":12577916,
         "hasc:id":"HU.CS",
+        "iso:code":"HU-CS",
         "iso:id":"HU-CS",
+        "qs:local_id":"706",
         "unlc:id":"HU-CS",
         "wd:id":"Q193031"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"4dbdc924c5cda6c24d69ae2901151d5b",
+    "wof:geomhash":"27b862c9ba2573b716b9887b526d2a28",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -486,7 +492,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930639,
+    "wof:lastmodified":1695885271,
     "wof:name":"Csongr\u00e1d",
     "wof:parent_id":404227487,
     "wof:placetype":"region",

--- a/data/856/848/59/85684859.geojson
+++ b/data/856/848/59/85684859.geojson
@@ -395,12 +395,18 @@
         "gn:id":3055744,
         "gp:id":12577911,
         "hasc:id":"HU.BK",
+        "iso:code":"HU-BK",
         "iso:id":"HU-BK",
+        "qs:local_id":"703",
         "unlc:id":"HU-BK",
         "wd:id":"Q181018"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"bca3a7065d57419f30cf9875c9732d81",
+    "wof:geomhash":"4b86308da533b62c587686cadff86fda",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -416,7 +422,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930637,
+    "wof:lastmodified":1695885271,
     "wof:name":"B\u00e1cs-Kiskun",
     "wof:parent_id":404227487,
     "wof:placetype":"region",

--- a/data/856/848/63/85684863.geojson
+++ b/data/856/848/63/85684863.geojson
@@ -384,12 +384,18 @@
         "gn:id":3043047,
         "gp:id":12577928,
         "hasc:id":"HU.VA",
+        "iso:code":"HU-VA",
         "iso:id":"HU-VA",
+        "qs:local_id":"318",
         "unlc:id":"HU-VA",
         "wd:id":"Q187677"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"7387478ba9cebc4d79dbea9de05d7792",
+    "wof:geomhash":"e7d177cd9f8625b5b6e20c6a14804ff4",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -405,7 +411,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930639,
+    "wof:lastmodified":1695885271,
     "wof:name":"Vas",
     "wof:parent_id":404227481,
     "wof:placetype":"region",

--- a/data/856/848/71/85684871.geojson
+++ b/data/856/848/71/85684871.geojson
@@ -319,12 +319,18 @@
         "eurostat:nuts_2021_id":"HU213",
         "fips:code":"HU23",
         "hasc:id":"HU.VE",
+        "iso:code":"HU-VE",
         "iso:id":"HU-VE",
+        "qs:local_id":"219",
         "unlc:id":"HU-VM",
         "wd:id":"Q188890"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"ddcd55c2ff7b3ffb7f943ec99e88d015",
+    "wof:geomhash":"207009f83ef7ad29a978f9099acf6ea5",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -340,7 +346,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930641,
+    "wof:lastmodified":1695885271,
     "wof:name":"Veszpr\u00e9m",
     "wof:parent_id":404227479,
     "wof:placetype":"region",

--- a/data/856/848/75/85684875.geojson
+++ b/data/856/848/75/85684875.geojson
@@ -373,12 +373,18 @@
         "gn:id":722433,
         "gp:id":12577913,
         "hasc:id":"HU.BE",
+        "iso:code":"HU-BE",
         "iso:id":"HU-BE",
+        "qs:local_id":"704",
         "unlc:id":"HU-BE",
         "wd:id":"Q191616"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"abeb6477bc82441e4d4d7420e4d87616",
+    "wof:geomhash":"24186fe8c54ab13271e28a76bb1c1a24",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -394,7 +400,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930637,
+    "wof:lastmodified":1695885271,
     "wof:name":"B\u00e9k\u00e9s",
     "wof:parent_id":404227487,
     "wof:placetype":"region",

--- a/data/856/848/79/85684879.geojson
+++ b/data/856/848/79/85684879.geojson
@@ -401,12 +401,18 @@
         "gn:id":3053028,
         "gp:id":12577917,
         "hasc:id":"HU.FE",
+        "iso:code":"HU-FE",
         "iso:id":"HU-FE",
+        "qs:local_id":"207",
         "unlc:id":"HU-FE",
         "wd:id":"Q187693"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"74c1065bb05987f749465e8933e7376d",
+    "wof:geomhash":"bbe7d4be70ff2ef95d2ccb2b125a206a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -422,7 +428,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930640,
+    "wof:lastmodified":1695885271,
     "wof:name":"Fej\u00e9r",
     "wof:parent_id":404227479,
     "wof:placetype":"region",

--- a/data/856/848/81/85684881.geojson
+++ b/data/856/848/81/85684881.geojson
@@ -803,15 +803,21 @@
         "gn:id":3054638,
         "gp:id":12577915,
         "hasc:id":"HU.BU",
+        "iso:code":"HU-BU",
         "iso:id":"HU-BU",
+        "qs:local_id":"101",
         "unlc:id":"HU-BU",
         "wd:id":"Q1781"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:coterminous":[
         101751703
     ],
     "wof:country":"HU",
-    "wof:geomhash":"a955eeabc3be897d68c39fcd7f2292aa",
+    "wof:geomhash":"851e4d1c102b8cb4a4971f08a42a2bc3",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -827,7 +833,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930638,
+    "wof:lastmodified":1695885271,
     "wof:name":"Budapest",
     "wof:parent_id":404227489,
     "wof:placetype":"region",

--- a/data/856/848/85/85684885.geojson
+++ b/data/856/848/85/85684885.geojson
@@ -398,12 +398,18 @@
         "gn:id":3049518,
         "gp:id":12577921,
         "hasc:id":"HU.KE",
+        "iso:code":"HU-KE",
         "iso:id":"HU-KE",
+        "qs:local_id":"211",
         "unlc:id":"HU-KE",
         "wd:id":"Q190018"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"a89bc48de5a0c5cc8fd2af5630fb8e7c",
+    "wof:geomhash":"908ac15ac73fe668d4801b76a40dff89",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -419,7 +425,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930640,
+    "wof:lastmodified":1695885271,
     "wof:name":"Kom\u00e1rom-Esztergom",
     "wof:parent_id":404227479,
     "wof:placetype":"region",

--- a/data/856/848/91/85684891.geojson
+++ b/data/856/848/91/85684891.geojson
@@ -391,12 +391,18 @@
         "gn:id":719637,
         "gp:id":12577926,
         "hasc:id":"HU.JN",
+        "iso:code":"HU-JN",
         "iso:id":"HU-JN",
+        "qs:local_id":"616",
         "unlc:id":"HU-SK",
         "wd:id":"Q189655"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"c9f9ce36766e01064c36bb690c5f127c",
+    "wof:geomhash":"ec8843415ee081de8cb00830cbcae29a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -412,7 +418,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930638,
+    "wof:lastmodified":1695885271,
     "wof:name":"J\u00e1sz-Nagykun-Szolnok",
     "wof:parent_id":404227483,
     "wof:placetype":"region",

--- a/data/856/848/95/85684895.geojson
+++ b/data/856/848/95/85684895.geojson
@@ -401,12 +401,18 @@
         "gn:id":3051977,
         "gp:id":12577918,
         "hasc:id":"HU.GS",
+        "iso:code":"HU-GS",
         "iso:id":"HU-GS",
+        "qs:local_id":"308",
         "unlc:id":"HU-SN",
         "wd:id":"Q187753"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"693227c43d18c43c1600dbf3b0addc1e",
+    "wof:geomhash":"dfee02ba47a217000d6cfb19e4930d67",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -422,7 +428,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930636,
+    "wof:lastmodified":1695885271,
     "wof:name":"Gyor-Moson-Sopron",
     "wof:parent_id":404227481,
     "wof:placetype":"region",

--- a/data/856/848/99/85684899.geojson
+++ b/data/856/848/99/85684899.geojson
@@ -379,12 +379,18 @@
         "gn:id":3046431,
         "gp:id":12577923,
         "hasc:id":"HU.PT",
+        "iso:code":"HU-PE",
         "iso:id":"HU-PE",
+        "qs:local_id":"113",
         "unlc:id":"HU-PE",
         "wd:id":"Q188612"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"48fed4e33f57fe474dbf2d8847d69a89",
+    "wof:geomhash":"78df9740711d6a6eeafbc943b03ad27b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +406,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930639,
+    "wof:lastmodified":1695885271,
     "wof:name":"Pest",
     "wof:parent_id":404227489,
     "wof:placetype":"region",

--- a/data/856/849/03/85684903.geojson
+++ b/data/856/849/03/85684903.geojson
@@ -388,12 +388,18 @@
         "gn:id":720293,
         "gp:id":12577919,
         "hasc:id":"HU.HB",
+        "iso:code":"HU-HB",
         "iso:id":"HU-HB",
+        "qs:local_id":"609",
         "unlc:id":"HU-HB",
         "wd:id":"Q185368"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"fc82d7c8d03bd1251509ac2d13fa233b",
+    "wof:geomhash":"e42c4c660ae2fa0fcf9a1bc3211ff640",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -409,7 +415,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930641,
+    "wof:lastmodified":1695885272,
     "wof:name":"Hajd\u00fa-Bihar",
     "wof:parent_id":404227483,
     "wof:placetype":"region",

--- a/data/856/849/09/85684909.geojson
+++ b/data/856/849/09/85684909.geojson
@@ -379,12 +379,18 @@
         "gn:id":720002,
         "gp:id":12577920,
         "hasc:id":"HU.HE",
+        "iso:code":"HU-HE",
         "iso:id":"HU-HE",
+        "qs:local_id":"510",
         "unlc:id":"HU-HE",
         "wd:id":"Q191604"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"d0c997bba3c732d57c75ebe8b07fa3e7",
+    "wof:geomhash":"73dedfd2da922e8234015850fcb349d9",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -400,7 +406,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930642,
+    "wof:lastmodified":1695885272,
     "wof:name":"Heves",
     "wof:parent_id":404227477,
     "wof:placetype":"region",

--- a/data/856/849/13/85684913.geojson
+++ b/data/856/849/13/85684913.geojson
@@ -373,12 +373,18 @@
         "gn:id":3047348,
         "gp:id":12577922,
         "hasc:id":"HU.NO",
+        "iso:code":"HU-NO",
         "iso:id":"HU-NO",
+        "qs:local_id":"512",
         "unlc:id":"HU-NO",
         "wd:id":"Q194273"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"bbcd4316eeb3424caa456d5347e7ea36",
+    "wof:geomhash":"2ad7c58110f4903fb69237e1492bfe2a",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -394,7 +400,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930643,
+    "wof:lastmodified":1695885272,
     "wof:name":"N\u00f3gr\u00e1d",
     "wof:parent_id":404227477,
     "wof:placetype":"region",

--- a/data/856/849/15/85684915.geojson
+++ b/data/856/849/15/85684915.geojson
@@ -409,12 +409,18 @@
         "gn:id":715593,
         "gp:id":12577925,
         "hasc:id":"HU.SZ",
+        "iso:code":"HU-SZ",
         "iso:id":"HU-SZ",
+        "qs:local_id":"615",
         "unlc:id":"HU-SZ",
         "wd:id":"Q190518"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"c2989d84a51c515560314f5596d37eb4",
+    "wof:geomhash":"53ec1ff283fc7ac0dbc96bca83a10d4b",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -430,7 +436,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930642,
+    "wof:lastmodified":1695885272,
     "wof:name":"Szabolcs-Szatm\u00e1r-Bereg",
     "wof:parent_id":404227483,
     "wof:placetype":"region",

--- a/data/856/849/19/85684919.geojson
+++ b/data/856/849/19/85684919.geojson
@@ -394,12 +394,18 @@
         "gn:id":722064,
         "gp:id":12577914,
         "hasc:id":"HU.BZ",
+        "iso:code":"HU-BZ",
         "iso:id":"HU-BZ",
+        "qs:local_id":"505",
         "unlc:id":"HU-BZ",
         "wd:id":"Q188895"
     },
+    "wof:concordances_official":"qs:local_id",
+    "wof:concordances_official_alt":[
+        "iso:code"
+    ],
     "wof:country":"HU",
-    "wof:geomhash":"29ba1b8bb0c9c64a91e057c97615baec",
+    "wof:geomhash":"418678becc9a97f278a9f81eb35318eb",
     "wof:hierarchy":[
         {
             "continent_id":102191581,
@@ -415,7 +421,7 @@
     "wof:lang_x_spoken":[
         "hun"
     ],
-    "wof:lastmodified":1690930642,
+    "wof:lastmodified":1695885272,
     "wof:name":"Borsod-Aba\u00faj-Zempl\u00e9n",
     "wof:parent_id":404227477,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.